### PR TITLE
Xtensa cache flushing

### DIFF
--- a/.github/workflows/smoketest.yml
+++ b/.github/workflows/smoketest.yml
@@ -25,7 +25,7 @@ jobs:
             aarch64-unknown-linux-gnu
 
       - name: Install cross 
-        uses: taiki-e/install-action@v2.21.26
+        uses: taiki-e/install-action@v2.22.0
         with:
           tool: cross
 

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,6 +7,28 @@
     {
       "type": "lldb",
       "request": "launch",
+      "name": "Debug example 'xtensa'",
+      "cargo": {
+        "args": [
+          "build",
+          "--example=xtensa",
+          "--package=probe-rs",
+          "--features=ftdi"
+        ],
+        "filter": {
+          "name": "xtensa",
+          "kind": "example"
+        }
+      },
+      "args": [],
+      "cwd": "${workspaceFolder}",
+      "env": {
+        "RUST_LOG": "info"
+      }
+    },
+    {
+      "type": "lldb",
+      "request": "launch",
       "name": "Launch smoke tester",
       "cargo": {
         "args": ["build", "--package=smoke_tester"]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -664,11 +664,10 @@ checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "colored"
-version = "2.0.4"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2674ec482fbc38012cf31e6c42ba0177b431a0cb6f15fe40efa5aab1bda516f6"
+checksum = "cbf2150cce219b664a8a70df7a1f933836724b503f8a413af9365b4dcc4d90b8"
 dependencies = [
- "is-terminal",
  "lazy_static",
  "windows-sys 0.48.0",
 ]
@@ -2228,9 +2227,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.18.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "openssl-probe"
@@ -3793,9 +3792,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.34.0"
+version = "1.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0c014766411e834f7af5b8f4cf46257aab4036ca95e9d2c144a10f59ad6f5b9"
+checksum = "841d45b238a16291a4e1584e61820b8ae57d696cc5015c459c229ccc6990cc1c"
 dependencies = [
  "backtrace",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -632,13 +632,11 @@ checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
 
 [[package]]
 name = "clipboard-win"
-version = "4.5.0"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7191c27c2357d9b7ef96baac1773290d4ca63b24205b82a3fd8a0637afcf0362"
+checksum = "c57002a5d9be777c1ef967e33674dac9ebd310d8893e4e3437b14d5f0f6372cc"
 dependencies = [
  "error-code",
- "str-buf",
- "winapi",
 ]
 
 [[package]]
@@ -1077,13 +1075,9 @@ dependencies = [
 
 [[package]]
 name = "error-code"
-version = "2.3.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64f18991e7bf11e7ffee451b5318b5c1a73c52d0d0ada6e5a3017c8c1ced6a21"
-dependencies = [
- "libc",
- "str-buf",
-]
+checksum = "281e452d3bad4005426416cdba5ccfd4f5c1280e10099e21db27f7c1c28347fc"
 
 [[package]]
 name = "esp-idf-part"
@@ -1140,13 +1134,13 @@ checksum = "6999dc1837253364c2ebb0704ba97994bd874e8f195d665c50b7548f6ea92764"
 
 [[package]]
 name = "fd-lock"
-version = "3.0.13"
+version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef033ed5e9bad94e55838ca0ca906db0e043f517adda0c8b79c7a8c66c93c1b5"
+checksum = "b93f7a0db71c99f68398f80653ed05afb0b00e062e1a20c7ff849c4edfabbbcc"
 dependencies = [
  "cfg-if",
  "rustix",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2142,6 +2136,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
+dependencies = [
+ "bitflags 2.4.1",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2961,9 +2966,9 @@ checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
 
 [[package]]
 name = "rustyline"
-version = "12.0.0"
+version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "994eca4bca05c87e86e15d90fc7a91d1be64b4482b38cb2d27474568fe7c9db9"
+checksum = "02a2d683a4ac90aeef5b1013933f6d977bd37d51ff3f4dad829d4931a7e6be86"
 dependencies = [
  "bitflags 2.4.1",
  "cfg-if",
@@ -2973,9 +2978,8 @@ dependencies = [
  "libc",
  "log",
  "memchr",
- "nix",
+ "nix 0.27.1",
  "radix_trie",
- "scopeguard",
  "unicode-segmentation",
  "unicode-width",
  "utf8parse",
@@ -3235,7 +3239,7 @@ dependencies = [
  "cfg-if",
  "libudev",
  "mach2",
- "nix",
+ "nix 0.26.2",
  "regex",
  "scopeguard",
  "winapi",
@@ -3395,12 +3399,6 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
-
-[[package]]
-name = "str-buf"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e08d8363704e6c71fc928674353e6b7c23dcea9d82d7012c8faf2a3a025f8d0"
 
 [[package]]
 name = "strsim"
@@ -4386,6 +4384,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.0",
+]
+
+[[package]]
 name = "windows-targets"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4416,6 +4423,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-targets"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.0",
+ "windows_aarch64_msvc 0.52.0",
+ "windows_i686_gnu 0.52.0",
+ "windows_i686_msvc 0.52.0",
+ "windows_x86_64_gnu 0.52.0",
+ "windows_x86_64_gnullvm 0.52.0",
+ "windows_x86_64_msvc 0.52.0",
+]
+
+[[package]]
 name = "windows_aarch64_gnullvm"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4426,6 +4448,12 @@ name = "windows_aarch64_gnullvm"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -4440,6 +4468,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
 
 [[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
+
+[[package]]
 name = "windows_i686_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4450,6 +4484,12 @@ name = "windows_i686_gnu"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -4464,6 +4504,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4474,6 +4520,12 @@ name = "windows_x86_64_gnu"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -4488,6 +4540,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4498,6 +4556,12 @@ name = "windows_x86_64_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
 
 [[package]]
 name = "winnow"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -744,6 +744,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6548a0ad5d2549e111e1f6a11a6c2e2d00ce6a3dafe22948d67c2b443f775e52"
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2492,6 +2502,7 @@ dependencies = [
  "thiserror",
  "time",
  "tracing",
+ "tracing-appender",
  "tracing-subscriber",
  "typed-path",
  "uf2-decode",
@@ -3909,6 +3920,18 @@ dependencies = [
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-appender"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3566e8ce28cc0a3fe42519fc80e6b4c943cc4c8cef275620eb8dac2d3d4e06cf"
+dependencies = [
+ "crossbeam-channel",
+ "thiserror",
+ "time",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/changelog/added-initial-xtensa-support.md
+++ b/changelog/added-initial-xtensa-support.md
@@ -1,0 +1,1 @@
+Added initial xtensa support.

--- a/changelog/changed-log-to-file-opt-in.md
+++ b/changelog/changed-log-to-file-opt-in.md
@@ -1,0 +1,1 @@
+Logging to file is now off by default. Use `--log-to-folder` or `--log-file` to enable.

--- a/changelog/fixed-flash-loader-not-loading-last-word.md
+++ b/changelog/fixed-flash-loader-not-loading-last-word.md
@@ -1,0 +1,1 @@
+Flash loader will now properly flash all bytes

--- a/changelog/fixed-single-buffer-transfer-speed.md
+++ b/changelog/fixed-single-buffer-transfer-speed.md
@@ -1,0 +1,1 @@
+Flasher: single buffer transfers are now done with u32 writes

--- a/probe-rs/Cargo.toml
+++ b/probe-rs/Cargo.toml
@@ -58,6 +58,7 @@ cli = [
     "dep:terminal_size",
     "dep:termtree",
     "dep:time",
+    "dep:tracing-appender",
     "dep:tracing-subscriber",
     "dep:git-version",
     "dep:serde_json",
@@ -184,6 +185,7 @@ tracing-subscriber = { version = "0.3.18", features = [
     "env-filter",
     "json",
 ], optional = true }
+tracing-appender = { version = "0.2.3", optional = true }
 ratatui = { version = "0.24.0", default-features = false, features = [
     "crossterm",
 ], optional = true }

--- a/probe-rs/Cargo.toml
+++ b/probe-rs/Cargo.toml
@@ -102,7 +102,7 @@ ihex = "3.0.0"
 jaylink = "0.3.0"
 jep106 = "0.2.8"
 kmp = { version = "0.1", optional = true }
-once_cell = "1.18.0"
+once_cell = "1.19.0"
 num-traits = "0.2.17"
 object = { version = "0.32.1", default-features = false, features = [
     "elf",
@@ -144,7 +144,7 @@ capstone = { version = "0.11.0", optional = true }
 cargo_metadata = { version = "0.18.1", optional = true }
 cargo_toml = { version = "0.17.1", optional = true }
 clap = { version = "4.4", features = ["derive"], optional = true }
-colored = { version = "2.0.4", optional = true }
+colored = { version = "2.1.0", optional = true }
 crossterm = { version = "<= 0.27.0", optional = true }
 defmt-decoder = { version = "0.3.9", features = ["unstable"], optional = true }
 directories = { version = "5", optional = true }

--- a/probe-rs/Cargo.toml
+++ b/probe-rs/Cargo.toml
@@ -165,7 +165,7 @@ parse_int = { version = "0.6.0", optional = true }
 pretty_env_logger = { workspace = true, optional = true }
 rand = { version = "0.8.5", optional = true }
 ron = { version = "0.8.1", optional = true }
-rustyline = { version = "12.0.0", optional = true }
+rustyline = { version = "13.0.0", optional = true }
 sanitize-filename = { version = "0.5", optional = true }
 schemafy = { version = "0.6", optional = true }
 serde_json = { version = "1", optional = true }

--- a/probe-rs/examples/xtensa.rs
+++ b/probe-rs/examples/xtensa.rs
@@ -1,0 +1,71 @@
+//! This example demonstrates how to use the implemented parts of the Xtensa interface.
+
+use anyhow::Result;
+use probe_rs::config::ScanChainElement;
+use probe_rs::{Lister, MemoryInterface, Probe};
+
+fn main() -> Result<()> {
+    pretty_env_logger::init();
+
+    // Get a list of all available debug probes.
+    let probe_lister = Lister::new();
+
+    let probes = probe_lister.list_all();
+
+    // Use the first probe found.
+    let mut probe: Probe = probes[0].open(&probe_lister)?;
+
+    probe.set_speed(100)?;
+    probe.select_protocol(probe_rs::WireProtocol::Jtag)?;
+
+    // Scan the chain for an esp32s3.
+    probe.set_scan_chain(vec![
+        ScanChainElement {
+            ir_len: Some(5),
+            name: Some("main".to_owned()),
+        },
+        ScanChainElement {
+            ir_len: Some(5),
+            name: Some("second".to_owned()),
+        },
+    ])?;
+    probe.attach_to_unspecified()?;
+    let mut iface = probe.try_into_xtensa_interface().unwrap();
+
+    iface.enter_ocd_mode()?;
+
+    assert!(iface.is_in_ocd_mode()?);
+
+    iface.halt()?;
+
+    const TEST_MEMORY_REGION_START: u64 = 0x600F_E000;
+    const TEST_MEMORY_LEN: usize = 100;
+
+    let mut saved_memory = [0; TEST_MEMORY_LEN];
+    iface.read(TEST_MEMORY_REGION_START, &mut saved_memory[..])?;
+
+    // Zero the memory
+    iface.write(TEST_MEMORY_REGION_START, &[0; TEST_MEMORY_LEN])?;
+
+    // Write a test word into memory, unaligned
+    iface.write_word_32(TEST_MEMORY_REGION_START + 1, 0xDECAFBAD)?;
+    let coffee_opinion = iface.read_word_32(TEST_MEMORY_REGION_START + 1)?;
+
+    // Write a test word into memory, aligned
+    iface.write_word_32(TEST_MEMORY_REGION_START + 8, 0xFEEDC0DE)?;
+    let aligned_word = iface.read_word_32(TEST_MEMORY_REGION_START + 8)?;
+
+    let mut readback = [0; 12];
+    iface.read(TEST_MEMORY_REGION_START, &mut readback[..])?;
+
+    tracing::info!("coffee_opinion: {:08X}", coffee_opinion);
+    tracing::info!("aligned_word: {:08X}", aligned_word);
+    tracing::info!("readback: {:X?}", readback);
+
+    // Restore memory we just overwrote
+    iface.write(TEST_MEMORY_REGION_START, &saved_memory[..])?;
+
+    iface.leave_ocd_mode()?;
+
+    Ok(())
+}

--- a/probe-rs/src/architecture/mod.rs
+++ b/probe-rs/src/architecture/mod.rs
@@ -2,3 +2,4 @@
 
 pub mod arm;
 pub mod riscv;
+pub mod xtensa;

--- a/probe-rs/src/architecture/riscv/mod.rs
+++ b/probe-rs/src/architecture/riscv/mod.rs
@@ -237,10 +237,15 @@ impl<'probe> CoreInterface for Riscv32<'probe> {
         // write 1 to the haltreq register, which is part
         // of the dmcontrol register
 
-        tracing::debug!(
-            "Before requesting halt, the Dmcontrol register value was: {:?}",
-            self.interface.read_dm_register::<Dmcontrol>()?
-        );
+        if tracing::enabled!(tracing::Level::DEBUG) {
+            // For some reason inlining this read into the log macro causes it to be printed
+            // even if debug prints are disabled.
+            let dmc = self.interface.read_dm_register::<Dmcontrol>()?;
+            tracing::debug!(
+                "Before requesting halt, the Dmcontrol register value was: {:?}",
+                dmc
+            );
+        }
 
         let mut dmcontrol = Dmcontrol(0);
 

--- a/probe-rs/src/architecture/xtensa/arch/instruction/format.rs
+++ b/probe-rs/src/architecture/xtensa/arch/instruction/format.rs
@@ -1,0 +1,17 @@
+//! Instruction formats implemented as functions.
+//!
+//! Instruction formats are common bytecode formats used to simplify instruction implementation.
+//! They are implemented with an opcode and a set of more-or-less standardised slots where
+//! instructions may define their operands.
+//!
+//! For more information, see the Xtensa ISA documentation.
+
+/// Implements the RSR instruction format.
+pub const fn rsr(opcode: u32, rs: u8, t: u8) -> u32 {
+    opcode | (rs as u32) << 8 | (t as u32 & 0x0F) << 4
+}
+
+/// Implements the RRI8 instruction format.
+pub const fn rri8(opcode: u32, at: u8, _as: u8, off: u8) -> u32 {
+    opcode | ((off as u32) << 16) | (_as as u32 & 0x0F) << 8 | (at as u32 & 0x0F) << 4
+}

--- a/probe-rs/src/architecture/xtensa/arch/instruction/mod.rs
+++ b/probe-rs/src/architecture/xtensa/arch/instruction/mod.rs
@@ -1,0 +1,68 @@
+use crate::architecture::xtensa::arch::{CpuRegister, SpecialRegister};
+
+pub mod format;
+
+#[derive(Clone, Copy, PartialEq, Debug)]
+pub enum Instruction {
+    /// Loads a 32-bit word from the address in `src` into `DDR`
+    /// Note: this is an illegal instruction when the processor is not in On-Chip Debug Mode
+    Lddr32P(CpuRegister),
+
+    /// Stores a 32-bit word from `DDR` to the address in `src`
+    /// Note: this is an illegal instruction when the processor is not in On-Chip Debug Mode
+    Sddr32P(CpuRegister),
+
+    /// Stores 8 bits from `at` to the address in `as` offset by a constant.
+    ///
+    /// This instruction can not access InstrRAM.
+    S8i(CpuRegister, CpuRegister, u8),
+
+    /// Reads `SpecialRegister` into `CpuRegister`
+    Rsr(SpecialRegister, CpuRegister),
+
+    /// Writes `CpuRegister` into `SpecialRegister`
+    Wsr(SpecialRegister, CpuRegister),
+
+    /// Invalidates the I-Cache at the address in `CpuRegister` + offset.
+    ///
+    /// The offset will be divided by 4 and has a maximum value of 1020.
+    Ihi(CpuRegister, u32),
+
+    /// Writes back and Invalidates the D-Cache at the address in `CpuRegister` + offset.
+    ///
+    /// The offset will be divided by 4 and has a maximum value of 1020.
+    Dhwbi(CpuRegister, u32),
+
+    /// Returns the Core to the Running state
+    Rfdo(u8),
+}
+
+/// The architecture supports multi-word instructions. This enum represents the different encodings
+// ... but we only support narrow ones for now
+pub enum InstructionEncoding {
+    /// Instruction encoding is narrow enough to fit into DIR0/DIR0EXEC
+    Narrow(u32),
+}
+
+impl Instruction {
+    pub fn encode(self) -> InstructionEncoding {
+        let narrow = match self {
+            Instruction::Lddr32P(src) => 0x0070E0 | (src.address() as u32 & 0x0F) << 8,
+            Instruction::Sddr32P(src) => 0x0070F0 | (src.address() as u32 & 0x0F) << 8,
+            Instruction::Rsr(sr, t) => format::rsr(0x030000, sr.address(), t.address()),
+            Instruction::Wsr(sr, t) => format::rsr(0x130000, sr.address(), t.address()),
+            Instruction::S8i(at, as_, offset) => {
+                format::rri8(0x004002, at.address(), as_.address(), offset)
+            }
+            Instruction::Ihi(src, offset) => {
+                format::rri8(0x0070E2, 0, src.address(), (offset / 4) as u8)
+            }
+            Instruction::Dhwbi(src, offset) => {
+                format::rri8(0x007052, 0, src.address(), (offset / 4) as u8)
+            }
+            Instruction::Rfdo(_) => 0xF1E000,
+        };
+
+        InstructionEncoding::Narrow(narrow)
+    }
+}

--- a/probe-rs/src/architecture/xtensa/arch/mod.rs
+++ b/probe-rs/src/architecture/xtensa/arch/mod.rs
@@ -1,0 +1,141 @@
+#![allow(unused)] // TODO remove
+
+use std::ops::Range;
+
+pub mod instruction;
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Hash)]
+pub enum Register {
+    Cpu(CpuRegister),
+    Special(SpecialRegister),
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Hash)]
+pub enum CpuRegister {
+    A0 = 0,
+    A1 = 1,
+    A2 = 2,
+    A3 = 3,
+    A4 = 4,
+    A5 = 5,
+    A6 = 6,
+    A7 = 7,
+    A8 = 8,
+    A9 = 9,
+    A10 = 10,
+    A11 = 11,
+    A12 = 12,
+    A13 = 13,
+    A14 = 14,
+    A15 = 15,
+}
+
+impl CpuRegister {
+    pub const fn scratch() -> Self {
+        Self::A3
+    }
+
+    pub const fn address(self) -> u8 {
+        self as u8
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Hash)]
+pub enum SpecialRegister {
+    Lbeg = 0,
+    Lend = 1,
+    Lcount = 2,
+    Sar = 3,
+    Br = 4,
+    Litbase = 5,
+    Scompare1 = 12,
+    AccLo = 16,
+    AccHi = 17,
+    M0 = 32,
+    M1 = 33,
+    M2 = 34,
+    M3 = 35,
+    Windowbase = 72,
+    Windowstart = 73,
+    PteVAddr = 83,
+    RAsid = 90,
+    // MpuEnB = 90,
+    ITlbCfg = 91,
+    DTlbCfg = 92,
+    // MpuCfg = 92,
+    ERAccess = 95,
+    IBreakEnable = 96,
+    Memctl = 97,
+    CacheAdrDis = 98,
+    AtomCtl = 99,
+    Ddr = 104,
+    Mepc = 106,
+    Meps = 107,
+    Mesave = 108,
+    Mesr = 109,
+    Mecr = 110,
+    MeVAddr = 111,
+    IBreakA0 = 128,
+    IBreakA1 = 129,
+    DBreakA0 = 144,
+    DBreakA1 = 145,
+    DBreakC0 = 160,
+    DBreakC1 = 161,
+    Epc1 = 177,
+    Epc2 = 178,
+    Epc3 = 179,
+    Epc4 = 180,
+    Epc5 = 181,
+    Epc6 = 182,
+    Epc7 = 183,
+    IBreakC0 = 192,
+    IBreakC1 = 193,
+    // Depc = 192,
+    Eps2 = 194,
+    Eps3 = 195,
+    Eps4 = 196,
+    Eps5 = 197,
+    Eps6 = 198,
+    Eps7 = 199,
+    ExcSave1 = 209,
+    ExcSave2 = 210,
+    ExcSave3 = 211,
+    ExcSave4 = 212,
+    ExcSave5 = 213,
+    ExcSave6 = 214,
+    ExcSave7 = 215,
+    CpEnable = 224,
+    // Interrupt = 226,
+    IntSet = 226,
+    IntClear = 227,
+    IntEnable = 228,
+    Ps = 230,
+    VecBase = 231,
+    ExcCause = 232,
+    DebugCause = 233,
+    CCount = 234,
+    Prid = 235,
+    ICount = 236,
+    ICountLevel = 237,
+    ExcVaddr = 238,
+    CCompare0 = 240,
+    CCompare1 = 241,
+    CCompare2 = 242,
+    Misc0 = 244,
+    Misc1 = 245,
+    Misc2 = 246,
+    Misc3 = 247,
+}
+
+#[allow(non_upper_case_globals)] // Aliasses have same style as other register names
+impl SpecialRegister {
+    // Aliasses
+    pub const MpuEnB: Self = Self::RAsid;
+    pub const MpuCfg: Self = Self::DTlbCfg;
+    pub const Depc: Self = Self::IBreakC0;
+    pub const Interrupt: Self = Self::IntSet;
+
+    pub const fn address(self) -> u8 {
+        self as u8
+    }
+}

--- a/probe-rs/src/architecture/xtensa/communication_interface.rs
+++ b/probe-rs/src/architecture/xtensa/communication_interface.rs
@@ -1,0 +1,484 @@
+//! Xtensa Debug Module Communication
+
+// TODO: remove
+#![allow(missing_docs)]
+
+use std::collections::HashMap;
+
+use crate::{
+    architecture::xtensa::arch::{
+        instruction::Instruction, CpuRegister, Register, SpecialRegister,
+    },
+    probe::JTAGAccess,
+    DebugProbeError, MemoryInterface,
+};
+
+use super::xdm::{Error as XdmError, Xdm};
+
+/// Possible Xtensa errors
+#[derive(thiserror::Error, Debug)]
+pub enum XtensaError {
+    /// An error originating from the DebugProbe
+    #[error("Debug Probe Error")]
+    DebugProbe(#[from] DebugProbeError),
+    /// Xtensa debug module error
+    #[error("Xtensa debug module error: {0}")]
+    XdmError(XdmError),
+}
+
+struct XtensaCommunicationInterfaceState {
+    /// Pairs of (register, value).
+    saved_registers: HashMap<Register, u32>,
+
+    print_exception_cause: bool,
+}
+
+/// A interface that implements controls for Xtensa cores.
+pub struct XtensaCommunicationInterface {
+    /// The Xtensa debug module
+    xdm: Xdm,
+
+    state: XtensaCommunicationInterfaceState,
+}
+
+impl XtensaCommunicationInterface {
+    /// Create the Xtensa communication interface using the underlying probe driver
+    pub fn new(probe: Box<dyn JTAGAccess>) -> Result<Self, (Box<dyn JTAGAccess>, DebugProbeError)> {
+        let xdm = Xdm::new(probe).map_err(|(probe, e)| match e {
+            XtensaError::DebugProbe(err) => (probe, err),
+            other_error => (probe, DebugProbeError::Other(other_error.into())),
+        })?;
+
+        let s = Self {
+            xdm,
+            state: XtensaCommunicationInterfaceState {
+                saved_registers: HashMap::new(),
+                print_exception_cause: true,
+            },
+        };
+
+        Ok(s)
+    }
+
+    pub fn enter_ocd_mode(&mut self) -> Result<(), XtensaError> {
+        self.xdm.enter_ocd_mode()?;
+        tracing::info!("Entered OCD mode");
+        Ok(())
+    }
+
+    pub fn is_in_ocd_mode(&mut self) -> Result<bool, XtensaError> {
+        self.xdm.is_in_ocd_mode()
+    }
+
+    pub fn leave_ocd_mode(&mut self) -> Result<(), XtensaError> {
+        self.resume()?;
+        self.xdm.leave_ocd_mode()?;
+        tracing::info!("Left OCD mode");
+        Ok(())
+    }
+
+    pub fn halt(&mut self) -> Result<(), XtensaError> {
+        self.xdm.halt()?;
+        Ok(())
+    }
+
+    pub fn resume(&mut self) -> Result<(), XtensaError> {
+        self.restore_registers()?;
+        self.xdm.resume()?;
+
+        Ok(())
+    }
+
+    fn read_cpu_register(&mut self, register: CpuRegister) -> Result<u32, XtensaError> {
+        self.execute_instruction(Instruction::Wsr(SpecialRegister::Ddr, register))?;
+        self.xdm.read_ddr()
+    }
+
+    fn read_special_register(&mut self, register: SpecialRegister) -> Result<u32, XtensaError> {
+        self.save_register(Register::Cpu(CpuRegister::scratch()))?;
+
+        // Read special register into the scratch register
+        self.execute_instruction(Instruction::Rsr(register, CpuRegister::scratch()))?;
+
+        // Write the scratch register into DDR
+        self.execute_instruction(Instruction::Wsr(
+            SpecialRegister::Ddr,
+            CpuRegister::scratch(),
+        ))?;
+
+        // Read DDR
+        self.xdm.read_ddr()
+    }
+
+    fn write_special_register(
+        &mut self,
+        register: SpecialRegister,
+        value: u32,
+    ) -> Result<(), XtensaError> {
+        self.save_register(Register::Cpu(CpuRegister::scratch()))?;
+        self.save_register(Register::Special(register))?;
+
+        tracing::debug!("Writing special register: {:?}", register);
+
+        self.xdm.write_ddr(value)?;
+
+        // DDR -> scratch
+        self.xdm.execute_instruction(Instruction::Rsr(
+            SpecialRegister::Ddr,
+            CpuRegister::scratch(),
+        ))?;
+
+        // scratch -> target special register
+        self.xdm
+            .execute_instruction(Instruction::Wsr(register, CpuRegister::scratch()))?;
+
+        Ok(())
+    }
+
+    fn write_cpu_register(&mut self, register: CpuRegister, value: u32) -> Result<(), XtensaError> {
+        self.save_register(Register::Cpu(register))?;
+
+        tracing::debug!("Writing register: {:?}", register);
+
+        self.xdm.write_ddr(value)?;
+        self.xdm
+            .execute_instruction(Instruction::Rsr(SpecialRegister::Ddr, register))?;
+
+        Ok(())
+    }
+
+    fn debug_execution_error_impl(&mut self, status: XdmError) -> Result<(), XtensaError> {
+        if let XdmError::ExecExeception = status {
+            if !self.state.print_exception_cause {
+                tracing::warn!("Instruction exception while reading previous exception");
+                return Ok(());
+            }
+
+            tracing::warn!("Failed to execute instruction, attempting to read debug info");
+
+            // clear ExecException to allow new instructions to run
+            self.xdm.clear_exec_exception()?;
+
+            for (name, reg) in [
+                ("EXCCAUSE", SpecialRegister::ExcCause),
+                ("EXCVADDR", SpecialRegister::ExcVaddr),
+                ("DEBUGCAUSE", SpecialRegister::DebugCause),
+            ] {
+                let register = self.read_register(Register::Special(reg))?;
+
+                tracing::info!("{}: {:08x}", name, register);
+            }
+        }
+
+        Ok(())
+    }
+
+    fn debug_execution_error(&mut self, status: XdmError) -> Result<(), XtensaError> {
+        self.state.print_exception_cause = false;
+        let result = self.debug_execution_error_impl(status);
+        self.state.print_exception_cause = true;
+
+        result
+    }
+
+    fn execute_instruction(&mut self, inst: Instruction) -> Result<(), XtensaError> {
+        let status = self.xdm.execute_instruction(inst);
+        if let Err(XtensaError::XdmError(err)) = status {
+            self.debug_execution_error(err)?
+        }
+        status
+    }
+
+    fn read_ddr_and_execute(&mut self) -> Result<u32, XtensaError> {
+        let status = self.xdm.read_ddr_and_execute();
+        if let Err(XtensaError::XdmError(err)) = status {
+            self.debug_execution_error(err)?
+        }
+        status
+    }
+
+    fn write_ddr_and_execute(&mut self, value: u32) -> Result<(), XtensaError> {
+        let status = self.xdm.write_ddr_and_execute(value);
+        if let Err(XtensaError::XdmError(err)) = status {
+            self.debug_execution_error(err)?
+        }
+        status
+    }
+
+    fn is_register_saved(&mut self, register: Register) -> bool {
+        if register == Register::Special(SpecialRegister::Ddr) {
+            // Avoid saving DDR
+            return true;
+        }
+        self.state.saved_registers.contains_key(&register)
+    }
+
+    fn read_register(&mut self, register: Register) -> Result<u32, XtensaError> {
+        match register {
+            Register::Cpu(register) => self.read_cpu_register(register),
+            Register::Special(register) => self.read_special_register(register),
+        }
+    }
+
+    fn save_register(&mut self, register: Register) -> Result<(), XtensaError> {
+        if !self.is_register_saved(register) {
+            tracing::debug!("Saving register: {:?}", register);
+            let value = self.read_register(register)?;
+            self.state.saved_registers.insert(register, value);
+        }
+
+        Ok(())
+    }
+
+    fn restore_registers(&mut self) -> Result<(), XtensaError> {
+        tracing::debug!("Restoring registers");
+
+        // Clone the list of saved registers so we can iterate over it, but code may still save
+        // new registers. We can't take it otherwise the restore loop would unnecessarily save
+        // registers.
+        // Currently, restoring registers may only use the scratch register which is already saved
+        // if we access special registers. This means the register list won't actually change in the
+        // next loop.
+        let dirty_regs = self.state.saved_registers.clone();
+        let mut restore_scratch = None;
+
+        for (register, value) in dirty_regs.iter().map(|(k, v)| (*k, *v)) {
+            match register {
+                Register::Cpu(register) if register == CpuRegister::scratch() => {
+                    // We need to handle the scratch register (A3) separately as restoring a special
+                    // register will overwrite it.
+                    restore_scratch = Some(value);
+                }
+                Register::Cpu(register) => self.write_cpu_register(register, value)?,
+                Register::Special(register) => self.write_special_register(register, value)?,
+            }
+        }
+
+        if self.state.saved_registers.len() != dirty_regs.len() {
+            // The scratch register wasn't saved before, but has to be saved now. This case should
+            // not currently be reachable.
+            restore_scratch = self
+                .state
+                .saved_registers
+                .get(&Register::Cpu(CpuRegister::scratch()))
+                .copied();
+        }
+
+        if let Some(value) = restore_scratch {
+            self.write_cpu_register(CpuRegister::scratch(), value)?;
+        }
+
+        self.state.saved_registers.clear();
+
+        Ok(())
+    }
+
+    fn write_memory_unaligned8(&mut self, address: u32, data: &[u8]) -> Result<(), crate::Error> {
+        if data.is_empty() {
+            return Ok(());
+        }
+
+        let offset = address as usize % 4;
+        let aligned_address = address & !0x3;
+
+        // Read the aligned word
+        let mut word = [0; 4];
+        self.read(aligned_address as u64, &mut word)?;
+
+        // Replace the written bytes. This will also panic if the input is crossing a word boundary
+        word[offset..][..data.len()].copy_from_slice(data);
+
+        // Write the word back
+        self.write_cpu_register(CpuRegister::A3, aligned_address)?;
+        self.xdm.write_ddr(u32::from_le_bytes(word))?;
+        self.execute_instruction(Instruction::Sddr32P(CpuRegister::A3))?;
+
+        Ok(())
+    }
+}
+
+/// DataType
+///
+/// # Safety
+/// Don't implement this trait
+unsafe trait DataType: Sized {}
+unsafe impl DataType for u8 {}
+unsafe impl DataType for u32 {}
+unsafe impl DataType for u64 {}
+
+fn as_bytes<T: DataType>(data: &[T]) -> &[u8] {
+    unsafe { std::slice::from_raw_parts(data.as_ptr() as *mut u8, std::mem::size_of_val(data)) }
+}
+
+fn as_bytes_mut<T: DataType>(data: &mut [T]) -> &mut [u8] {
+    unsafe {
+        std::slice::from_raw_parts_mut(data.as_mut_ptr() as *mut u8, std::mem::size_of_val(data))
+    }
+}
+
+impl MemoryInterface for XtensaCommunicationInterface {
+    fn read(&mut self, address: u64, mut dst: &mut [u8]) -> Result<(), crate::Error> {
+        if dst.is_empty() {
+            return Ok(());
+        }
+
+        // Write aligned address to the scratch register
+        self.write_cpu_register(CpuRegister::scratch(), address as u32 & !0x3)?;
+
+        // Read from address in the scratch register
+        self.execute_instruction(Instruction::Lddr32P(CpuRegister::scratch()))?;
+
+        // Let's assume we can just do 32b reads, so let's do some pre-massaging on unaligned reads
+        if address % 4 != 0 {
+            let offset = address as usize % 4;
+
+            // Avoid executing another read if we only have to read a single word
+            let word = if offset + dst.len() <= 4 {
+                self.xdm.read_ddr()?
+            } else {
+                self.read_ddr_and_execute()?
+            };
+
+            let word = word.to_le_bytes();
+
+            let bytes_to_copy = (4 - offset).min(dst.len());
+
+            dst[..bytes_to_copy].copy_from_slice(&word[offset..][..bytes_to_copy]);
+            dst = &mut dst[bytes_to_copy..];
+
+            if dst.is_empty() {
+                return Ok(());
+            }
+        }
+
+        while dst.len() > 4 {
+            let word = self.read_ddr_and_execute()?.to_le_bytes();
+            dst[..4].copy_from_slice(&word);
+            dst = &mut dst[4..];
+        }
+
+        let remaining_bytes = dst.len();
+
+        let word = self.xdm.read_ddr()?;
+        dst.copy_from_slice(&word.to_le_bytes()[..remaining_bytes]);
+
+        Ok(())
+    }
+
+    fn read_word_32(&mut self, address: u64) -> Result<u32, crate::Error> {
+        let mut out = [0; 4];
+        self.read(address, &mut out)?;
+
+        Ok(u32::from_le_bytes(out))
+    }
+
+    fn supports_native_64bit_access(&mut self) -> bool {
+        false
+    }
+
+    fn read_word_64(&mut self, address: u64) -> anyhow::Result<u64, crate::Error> {
+        let mut out = [0; 8];
+        self.read(address, &mut out)?;
+
+        Ok(u64::from_le_bytes(out))
+    }
+
+    fn read_word_8(&mut self, address: u64) -> anyhow::Result<u8, crate::Error> {
+        let mut out = 0;
+        self.read(address, std::slice::from_mut(&mut out))?;
+        Ok(out)
+    }
+
+    fn read_64(&mut self, address: u64, data: &mut [u64]) -> anyhow::Result<(), crate::Error> {
+        self.read_8(address, as_bytes_mut(data))
+    }
+
+    fn read_32(&mut self, address: u64, data: &mut [u32]) -> anyhow::Result<(), crate::Error> {
+        self.read_8(address, as_bytes_mut(data))
+    }
+
+    fn read_8(&mut self, address: u64, data: &mut [u8]) -> anyhow::Result<(), crate::Error> {
+        self.read(address, data)
+    }
+
+    fn write(&mut self, address: u64, data: &[u8]) -> Result<(), crate::Error> {
+        if data.is_empty() {
+            return Ok(());
+        }
+
+        let address = address as u32;
+
+        let mut addr = address;
+        let mut buffer = data;
+
+        // We store the unaligned head of the data separately
+        if addr % 4 != 0 {
+            let unaligned_bytes = (4 - (addr % 4) as usize).min(buffer.len());
+
+            self.write_memory_unaligned8(addr, &buffer[..unaligned_bytes])?;
+
+            buffer = &buffer[unaligned_bytes..];
+            addr += unaligned_bytes as u32;
+        }
+
+        if buffer.len() > 4 {
+            // Prepare store instruction
+            self.write_cpu_register(CpuRegister::A3, addr)?;
+            self.xdm
+                .write_instruction(Instruction::Sddr32P(CpuRegister::A3))?;
+
+            while buffer.len() > 4 {
+                let mut word = [0; 4];
+                word[..].copy_from_slice(&buffer[..4]);
+                let word = u32::from_le_bytes(word);
+
+                // Write data to DDR and store
+                self.write_ddr_and_execute(word)?;
+
+                buffer = &buffer[4..];
+                addr += 4;
+            }
+        }
+
+        // We store the narrow tail of the data separately
+        if !buffer.is_empty() {
+            self.write_memory_unaligned8(addr, buffer)?;
+        }
+
+        // TODO: implement cache flushing on CPUs that need it.
+
+        Ok(())
+    }
+
+    fn write_word_64(&mut self, address: u64, data: u64) -> anyhow::Result<(), crate::Error> {
+        self.write(address, &data.to_le_bytes())
+    }
+
+    fn write_word_32(&mut self, address: u64, data: u32) -> anyhow::Result<(), crate::Error> {
+        self.write(address, &data.to_le_bytes())
+    }
+
+    fn write_word_8(&mut self, address: u64, data: u8) -> anyhow::Result<(), crate::Error> {
+        self.write(address, &[data])
+    }
+
+    fn write_64(&mut self, address: u64, data: &[u64]) -> anyhow::Result<(), crate::Error> {
+        self.write_8(address, as_bytes(data))
+    }
+
+    fn write_32(&mut self, address: u64, data: &[u32]) -> anyhow::Result<(), crate::Error> {
+        self.write_8(address, as_bytes(data))
+    }
+
+    fn write_8(&mut self, address: u64, data: &[u8]) -> anyhow::Result<(), crate::Error> {
+        self.write(address, data)
+    }
+
+    fn supports_8bit_transfers(&self) -> anyhow::Result<bool, crate::Error> {
+        Ok(true)
+    }
+
+    fn flush(&mut self) -> anyhow::Result<(), crate::Error> {
+        Ok(())
+    }
+}

--- a/probe-rs/src/architecture/xtensa/communication_interface.rs
+++ b/probe-rs/src/architecture/xtensa/communication_interface.rs
@@ -7,7 +7,8 @@ use std::collections::HashMap;
 
 use crate::{
     architecture::xtensa::arch::{
-        instruction::Instruction, CpuRegister, Register, SpecialRegister,
+        instruction::Instruction, CacheConfig, ChipConfig, CpuRegister, MemoryConfig, MemoryRegion,
+        Register, SpecialRegister,
     },
     probe::JTAGAccess,
     DebugProbeError, MemoryInterface,
@@ -31,6 +32,8 @@ struct XtensaCommunicationInterfaceState {
     saved_registers: HashMap<Register, u32>,
 
     print_exception_cause: bool,
+
+    config: ChipConfig,
 }
 
 /// A interface that implements controls for Xtensa cores.
@@ -54,6 +57,78 @@ impl XtensaCommunicationInterface {
             state: XtensaCommunicationInterfaceState {
                 saved_registers: HashMap::new(),
                 print_exception_cause: true,
+                config: ChipConfig {
+                    // ESP32-S3
+                    icache: CacheConfig {
+                        line_size: 0,
+                        size: 0,
+                        way_count: 1,
+                    },
+                    dcache: CacheConfig {
+                        line_size: 0,
+                        size: 0,
+                        way_count: 1,
+                    },
+
+                    sram: MemoryConfig { regions: vec![] },
+                    srom: MemoryConfig { regions: vec![] },
+                    iram: MemoryConfig {
+                        regions: vec![
+                            MemoryRegion {
+                                addr: 0x40370000,
+                                size: 0x70000,
+                            },
+                            MemoryRegion {
+                                addr: 0x600FE000,
+                                size: 0x2000,
+                            },
+                        ],
+                    },
+                    irom: MemoryConfig {
+                        regions: vec![
+                            MemoryRegion {
+                                addr: 0x42000000,
+                                size: 0x2000000,
+                            },
+                            MemoryRegion {
+                                addr: 0x40000000,
+                                size: 0x60000,
+                            },
+                        ],
+                    },
+                    dram: MemoryConfig {
+                        regions: vec![
+                            MemoryRegion {
+                                addr: 0x3FC88000,
+                                size: 0x78000,
+                            },
+                            MemoryRegion {
+                                addr: 0x600FE000,
+                                size: 0x2000,
+                            },
+                            MemoryRegion {
+                                addr: 0x50000000,
+                                size: 0x2000,
+                            },
+                            MemoryRegion {
+                                addr: 0x60000000,
+                                size: 0x10000000,
+                            },
+                        ],
+                    },
+                    drom: MemoryConfig {
+                        regions: vec![
+                            MemoryRegion {
+                                addr: 0x3C000000,
+                                size: 0x1000000,
+                            },
+                            MemoryRegion {
+                                addr: 0x3FF00000,
+                                size: 0x20000,
+                            },
+                        ],
+                    },
+                },
             },
         };
 
@@ -445,7 +520,48 @@ impl MemoryInterface for XtensaCommunicationInterface {
             self.write_memory_unaligned8(addr, buffer)?;
         }
 
-        // TODO: implement cache flushing on CPUs that need it.
+        // flush caches if we need to
+        let flush_icache = self.state.config.is_icacheable(address as u32);
+        let flush_dcache = self.state.config.is_dcacheable(address as u32);
+
+        let line_size = match (flush_icache, flush_dcache) {
+            (true, true) => self
+                .state
+                .config
+                .icache
+                .line_size
+                .max(self.state.config.dcache.line_size),
+            (true, false) => self.state.config.icache.line_size,
+            (false, true) => self.state.config.dcache.line_size,
+            (false, false) => {
+                // Written memory can't be cached, so we don't need to flush
+                return Ok(());
+            }
+        };
+
+        let mut off = 0;
+        let mut addr = address & !0x03;
+        let addr_end = addr + data.len() as u32;
+
+        while addr + off < addr_end {
+            if off == 0 {
+                self.write_cpu_register(CpuRegister::A3, addr)?;
+            }
+
+            if flush_icache {
+                self.execute_instruction(Instruction::Ihi(CpuRegister::A3, off))?;
+            }
+            if flush_dcache {
+                self.execute_instruction(Instruction::Dhwbi(CpuRegister::A3, off))?;
+            }
+
+            off += line_size;
+
+            if off > 1020 {
+                addr += off;
+                off = 0;
+            }
+        }
 
         Ok(())
     }

--- a/probe-rs/src/architecture/xtensa/mod.rs
+++ b/probe-rs/src/architecture/xtensa/mod.rs
@@ -1,0 +1,88 @@
+//! All the interface bits for Xtensa.
+
+use crate::{Error, MemoryInterface};
+
+use self::communication_interface::XtensaCommunicationInterface;
+
+mod arch;
+mod xdm;
+
+pub mod communication_interface;
+
+/// An interface to operate Xtensa cores.
+pub struct Xtensa<'probe> {
+    interface: &'probe mut XtensaCommunicationInterface,
+}
+
+impl<'probe> Xtensa<'probe> {
+    /// Create a new Xtensa interface.
+    pub fn new(interface: &'probe mut XtensaCommunicationInterface) -> Self {
+        Self { interface }
+    }
+}
+
+impl<'probe> MemoryInterface for Xtensa<'probe> {
+    fn supports_native_64bit_access(&mut self) -> bool {
+        self.interface.supports_native_64bit_access()
+    }
+
+    fn read_word_64(&mut self, address: u64) -> Result<u64, Error> {
+        self.interface.read_word_64(address)
+    }
+
+    fn read_word_32(&mut self, address: u64) -> Result<u32, Error> {
+        self.interface.read_word_32(address)
+    }
+
+    fn read_word_8(&mut self, address: u64) -> Result<u8, Error> {
+        self.interface.read_word_8(address)
+    }
+
+    fn read_64(&mut self, address: u64, data: &mut [u64]) -> Result<(), Error> {
+        self.interface.read_64(address, data)
+    }
+
+    fn read_32(&mut self, address: u64, data: &mut [u32]) -> Result<(), Error> {
+        self.interface.read_32(address, data)
+    }
+
+    fn read_8(&mut self, address: u64, data: &mut [u8]) -> Result<(), Error> {
+        self.interface.read_8(address, data)
+    }
+
+    fn write_word_64(&mut self, address: u64, data: u64) -> Result<(), Error> {
+        self.interface.write_word_64(address, data)
+    }
+
+    fn write_word_32(&mut self, address: u64, data: u32) -> Result<(), Error> {
+        self.interface.write_word_32(address, data)
+    }
+
+    fn write_word_8(&mut self, address: u64, data: u8) -> Result<(), Error> {
+        self.interface.write_word_8(address, data)
+    }
+
+    fn write_64(&mut self, address: u64, data: &[u64]) -> Result<(), Error> {
+        self.interface.write_64(address, data)
+    }
+
+    fn write_32(&mut self, address: u64, data: &[u32]) -> Result<(), Error> {
+        self.interface.write_32(address, data)
+    }
+
+    fn write_8(&mut self, address: u64, data: &[u8]) -> Result<(), Error> {
+        self.interface.write_8(address, data)
+    }
+
+    fn write(&mut self, address: u64, data: &[u8]) -> Result<(), Error> {
+        self.interface.write(address, data)
+    }
+
+    fn supports_8bit_transfers(&self) -> Result<bool, Error> {
+        self.interface.supports_8bit_transfers()
+    }
+
+    fn flush(&mut self) -> Result<(), Error> {
+        self.interface.flush()
+    }
+}

--- a/probe-rs/src/architecture/xtensa/xdm.rs
+++ b/probe-rs/src/architecture/xtensa/xdm.rs
@@ -1,0 +1,764 @@
+#![allow(unused)] // FIXME remove after testing
+
+use std::fmt::Debug;
+
+use crate::{
+    architecture::{
+        arm::ap::DRW,
+        xtensa::arch::instruction::{self, Instruction, InstructionEncoding},
+    },
+    probe::{JTAGAccess, JtagWriteCommand},
+    DebugProbeError,
+};
+
+use super::communication_interface::XtensaError;
+
+const NARADR_OCDID: u8 = 0x40;
+const NARADR_DCRSET: u8 = 0x43;
+const NARADR_DCRCLR: u8 = 0x42;
+const NARADR_DSR: u8 = 0x44;
+const NARADR_DDR: u8 = 0x45;
+const NARADR_DDREXEC: u8 = 0x46;
+// DIR0 that also executes when written
+const NARADR_DIR0EXEC: u8 = 0x47;
+// Assume we only support 16-24b instructions for now
+const NARADR_DIR0: u8 = 0x48;
+
+#[derive(Clone, Copy, PartialEq, Debug)]
+enum TapInstruction {
+    Nar,
+    Ndr,
+    PowerControl,
+    PowerStatus,
+}
+
+impl TapInstruction {
+    fn code(self) -> u32 {
+        match self {
+            TapInstruction::Nar => 0x1C,
+            TapInstruction::Ndr => 0x1C,
+            TapInstruction::PowerControl => 0x08,
+            TapInstruction::PowerStatus => 0x09,
+        }
+    }
+
+    fn bits(self) -> u32 {
+        match self {
+            TapInstruction::Nar => 8,
+            TapInstruction::Ndr => 32,
+            TapInstruction::PowerControl => 8,
+            TapInstruction::PowerStatus => 8,
+        }
+    }
+
+    fn capture_to_u32(self, capture: &[u8]) -> u32 {
+        match self {
+            TapInstruction::Ndr => u32::from_le_bytes(capture.try_into().unwrap()),
+            _ => capture[0] as u32,
+        }
+    }
+}
+
+/// Power registers are separate from the other registers. They are part of the Access Port.
+#[derive(Clone, Copy, PartialEq, Debug)]
+enum PowerDevice {
+    /// Power Control
+    PowerControl,
+    /// Power status
+    PowerStat,
+}
+
+impl From<PowerDevice> for TapInstruction {
+    fn from(dev: PowerDevice) -> Self {
+        match dev {
+            PowerDevice::PowerControl => TapInstruction::PowerControl,
+            PowerDevice::PowerStat => TapInstruction::PowerStatus,
+        }
+    }
+}
+
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub enum DebugRegisterStatus {
+    Ok,
+    Busy,
+    Error,
+}
+
+#[derive(thiserror::Error, Debug, Copy, Clone)]
+pub enum DebugRegisterError {
+    #[error("Register-specific error")]
+    Error,
+
+    #[error("Unexpected value")]
+    Unexpected,
+}
+
+fn parse_register_status(byte: u8) -> Result<DebugRegisterStatus, DebugRegisterError> {
+    match byte & 0b00000011 {
+        0 => Ok(DebugRegisterStatus::Ok),
+        1 => Ok(DebugRegisterStatus::Error),
+        2 => Ok(DebugRegisterStatus::Busy),
+        _ => {
+            // It is not specified if both bits can be 1 at the same time.
+            Err(DebugRegisterError::Unexpected)
+        }
+    }
+}
+
+#[derive(thiserror::Error, Debug, Clone, Copy)]
+pub enum Error {
+    #[error("Error while accessing register: {0}")]
+    Xdm(DebugRegisterError),
+
+    #[error("ExecExeception")]
+    ExecExeception,
+
+    #[error("ExecBusy")]
+    ExecBusy,
+
+    #[error("ExecOverrun")]
+    ExecOverrun,
+
+    #[error("XdmPoweredOff")]
+    XdmPoweredOff,
+}
+
+#[derive(Debug)]
+pub struct Xdm {
+    pub probe: Box<dyn JTAGAccess>,
+
+    queued_commands: Vec<JtagWriteCommand>,
+
+    device_id: u32,
+    idle_cycles: u8,
+
+    last_instruction: Option<Instruction>,
+}
+
+impl Xdm {
+    pub fn new(mut probe: Box<dyn JTAGAccess>) -> Result<Self, (Box<dyn JTAGAccess>, XtensaError)> {
+        // TODO implement openocd's esp32_queue_tdi_idle() to prevent potentially damaging flash ICs
+
+        // fixed to 5 bits for now
+        probe.set_ir_len(5);
+
+        let mut x = Self {
+            probe,
+            queued_commands: Vec::new(),
+            device_id: 0,
+            idle_cycles: 0,
+            last_instruction: None,
+        };
+
+        if let Err(e) = x.init() {
+            return Err((x.free(), e));
+        }
+
+        Ok(x)
+    }
+
+    fn init(&mut self) -> Result<(), XtensaError> {
+        let mut pwr_control = PowerControl(0);
+
+        pwr_control.set_debug_wakeup(true);
+        pwr_control.set_mem_wakeup(true);
+        pwr_control.set_core_wakeup(true);
+
+        // Wakeup and enable the JTAG
+        self.pwr_write(PowerDevice::PowerControl, pwr_control.0)?;
+
+        tracing::trace!("Waiting for power domain to turn on");
+        loop {
+            let bits = self.pwr_read(PowerDevice::PowerStat)?;
+            if PowerStatus(bits).debug_domain_on() {
+                break;
+            }
+        }
+
+        // Set JTAG_DEBUG_USE separately to ensure it doesn't get reset by a previous write.
+        // We don't reset anything but this is a good practice to avoid sneaky issues.
+        pwr_control.set_jtag_debug_use(true);
+        self.pwr_write(PowerDevice::PowerControl, pwr_control.0)?;
+
+        // enable the debug module
+        self.dbg_write(NARADR_DCRSET, 1)?;
+
+        // read the device_id
+        let device_id = self.dbg_read(NARADR_OCDID)?;
+
+        if device_id == 0 || device_id == !0 {
+            return Err(DebugProbeError::TargetNotFound.into());
+        }
+
+        let status = self.status()?;
+        tracing::info!("{:?}", status);
+
+        // we might find that an old instruction execution left the core with an exception
+        // try to clear problematic bits
+        self.write_nexus_register({
+            let mut status = DebugStatus(0);
+
+            status.set_exec_exception(true);
+            status.set_exec_done(true);
+            status.set_exec_overrun(true);
+            status.set_debug_pend_break(true);
+            status.set_debug_pend_host(true);
+
+            status
+        })?;
+
+        // TODO check status and clear bits if required
+
+        tracing::info!("Found Xtensa device with OCDID: 0x{:08X}", device_id);
+        self.device_id = device_id;
+
+        Ok(())
+    }
+
+    pub fn clear_exec_exception(&mut self) -> Result<(), XtensaError> {
+        self.write_nexus_register({
+            let mut status = DebugStatus(0);
+
+            status.set_exec_exception(true);
+
+            status
+        })?;
+
+        Ok(())
+    }
+
+    fn tap_write(&mut self, instr: TapInstruction, data: u32) -> Result<u32, DebugProbeError> {
+        let capture = self
+            .probe
+            .write_register(instr.code(), &data.to_le_bytes(), instr.bits())?;
+
+        Ok(instr.capture_to_u32(&capture))
+    }
+
+    fn tap_read(&mut self, instr: TapInstruction) -> Result<u32, DebugProbeError> {
+        let capture = self.probe.read_register(instr.code(), instr.bits())?;
+
+        Ok(instr.capture_to_u32(&capture))
+    }
+
+    /// Perform an access to a register
+    fn dbg_read(&mut self, address: u8) -> Result<u32, XtensaError> {
+        let regdata = address << 1;
+
+        self.tap_write(TapInstruction::Nar, regdata as u32);
+        let res = self.tap_read(TapInstruction::Ndr);
+
+        tracing::trace!("dbg_read response: {:?}", res);
+
+        Ok(res?)
+    }
+
+    /// Perform an access to a register
+    fn dbg_write(&mut self, address: u8, value: u32) -> Result<u32, XtensaError> {
+        let regdata = (address << 1) | 1;
+
+        self.tap_write(TapInstruction::Nar, regdata as u32);
+        let res = self.tap_write(TapInstruction::Ndr, value);
+
+        tracing::trace!("dbg_write response: {:?}", res);
+
+        Ok(res?)
+    }
+
+    fn dbg_status(&mut self) -> Result<DebugRegisterStatus, XtensaError> {
+        let status = self.tap_read(TapInstruction::Nar);
+        self.tap_read(TapInstruction::Ndr)?;
+
+        Ok(parse_register_status(status? as u8)?)
+    }
+
+    fn pwr_write(&mut self, dev: PowerDevice, value: u8) -> Result<u8, XtensaError> {
+        let res = self.tap_write(dev.into(), value as u32)?;
+        tracing::trace!("pwr_write response: {:?}", res);
+
+        Ok(res as u8)
+    }
+
+    fn pwr_read(&mut self, dev: PowerDevice) -> Result<u8, XtensaError> {
+        let res = self.tap_read(dev.into())?;
+        tracing::trace!("pwr_read response: {:?}", res);
+
+        Ok(res as u8)
+    }
+
+    fn read_nexus_register<R: NexusRegister>(&mut self) -> Result<R, XtensaError> {
+        tracing::debug!("Reading from {}", R::NAME);
+        let bits = self.dbg_read(R::ADDRESS)?;
+
+        // TODO: this is inefficient - we should queue up the reads and then read them all at once
+        self.dbg_status()?;
+
+        let reg = R::from_bits(bits)?;
+        tracing::debug!("Read: {:?}", reg);
+        Ok(reg)
+    }
+
+    fn write_nexus_register<R: NexusRegister>(&mut self, register: R) -> Result<(), XtensaError> {
+        tracing::debug!("Writing {}: {:08x}", R::NAME, register.bits());
+        self.dbg_write(R::ADDRESS, register.bits())?;
+
+        // TODO: we should queue the first status read
+
+        // TODO: timeout
+        while self.dbg_status()? == DebugRegisterStatus::Busy {
+            tracing::trace!("Waiting for write to complete");
+        }
+
+        Ok(())
+    }
+
+    fn status(&mut self) -> Result<DebugStatus, XtensaError> {
+        self.read_nexus_register::<DebugStatus>()
+    }
+
+    fn wait_for_exec_done(&mut self) -> Result<(), XtensaError> {
+        // TODO add timeout
+        loop {
+            let status = self.status()?;
+
+            if status.exec_overrun() {
+                return Err(Error::ExecOverrun.into());
+            }
+            if status.exec_exception() {
+                // TODO: we probably don't want to clear all clearable status bits.
+                self.write_nexus_register(status);
+                // TODO: we also probably don't want to crash if an exception happens here
+                return Err(Error::ExecExeception.into());
+            }
+
+            if !status.exec_busy() {
+                if status.exec_done() {
+                    return Ok(());
+                }
+
+                tracing::warn!("Instruction ignored: {:?}", self.last_instruction.unwrap());
+                return Ok(());
+            }
+        }
+    }
+
+    /// Instructs Core to enter Core Stopped state instead of vectoring on a Debug Exception/Interrupt.
+    pub(super) fn enter_ocd_mode(&mut self) -> Result<(), XtensaError> {
+        self.write_nexus_register(DebugControlSet({
+            let mut control = DebugControlBits(0);
+
+            control.set_enable_ocd(true);
+
+            control
+        }))?;
+        self.write_nexus_register(DebugControlClear({
+            let mut control = DebugControlBits(0);
+
+            control.set_break_in_en(true);
+            control.set_break_out_en(true);
+            control.set_run_stall_in_en(true);
+            control.set_debug_mode_out_en(true);
+
+            control
+        }))?;
+        self.write_nexus_register({
+            let mut status = DebugStatus(0);
+
+            status.set_debug_pend_break(true);
+            status.set_debug_int_break(true);
+            status.set_exec_overrun(true);
+            status.set_exec_exception(true);
+
+            status
+        });
+
+        Ok(())
+    }
+
+    pub(super) fn is_in_ocd_mode(&mut self) -> Result<bool, XtensaError> {
+        let reg = self.read_nexus_register::<DebugControlSet>()?;
+        Ok(reg.0.enable_ocd())
+    }
+
+    pub(super) fn leave_ocd_mode(&mut self) -> Result<(), XtensaError> {
+        // clear all clearable status bits
+        self.write_nexus_register({
+            let mut clear_status = DebugStatus(0);
+
+            clear_status.set_exec_done(true);
+            clear_status.set_exec_exception(true);
+            clear_status.set_exec_overrun(true);
+            clear_status.set_core_wrote_ddr(true);
+            clear_status.set_core_read_ddr(true);
+            clear_status.set_host_wrote_ddr(true);
+            clear_status.set_host_read_ddr(true);
+            clear_status.set_debug_pend_break(true);
+            clear_status.set_debug_pend_host(true);
+            clear_status.set_debug_pend_trax(true);
+            clear_status.set_debug_int_break(true);
+            clear_status.set_debug_int_host(true);
+            clear_status.set_debug_int_trax(true);
+            clear_status.set_run_stall_toggle(true);
+
+            clear_status
+        })?;
+
+        self.write_nexus_register(DebugControlClear({
+            let mut control = DebugControlBits(0);
+
+            control.set_enable_ocd(true);
+
+            control
+        }))?;
+
+        Ok(())
+    }
+
+    pub(super) fn halt(&mut self) -> Result<(), XtensaError> {
+        self.write_nexus_register(DebugControlSet({
+            let mut control = DebugControlBits(0);
+
+            control.set_debug_interrupt(true);
+
+            control
+        }))?;
+
+        Ok(())
+    }
+
+    pub(super) fn resume(&mut self) -> Result<(), XtensaError> {
+        // Clear pending interrupts first that would re-enter us into the Stopped state
+        self.write_nexus_register({
+            let mut clear_status = DebugStatus(0);
+
+            clear_status.set_debug_pend_host(true);
+            clear_status.set_debug_pend_break(true);
+
+            clear_status
+        })?;
+
+        self.execute_instruction(Instruction::Rfdo(0))?;
+
+        Ok(())
+    }
+
+    pub fn write_instruction(&mut self, instruction: Instruction) -> Result<(), XtensaError> {
+        tracing::debug!("Preparing instruction: {:?}", instruction);
+        self.last_instruction = Some(instruction);
+
+        match instruction.encode() {
+            InstructionEncoding::Narrow(inst) => {
+                self.write_nexus_register(DebugInstructionRegister(inst))
+            }
+        }
+    }
+
+    pub fn execute_instruction(&mut self, instruction: Instruction) -> Result<(), XtensaError> {
+        tracing::debug!("Executing instruction: {:?}", instruction);
+        self.last_instruction = Some(instruction);
+
+        match instruction.encode() {
+            InstructionEncoding::Narrow(inst) => {
+                self.write_nexus_register(DebugInstructionAndExecRegister(inst))?;
+            }
+        }
+
+        self.wait_for_exec_done()
+    }
+
+    pub fn read_ddr(&mut self) -> Result<u32, XtensaError> {
+        let reg = self.read_nexus_register::<DebugDataRegister>()?;
+        Ok(reg.bits())
+    }
+
+    pub fn write_ddr(&mut self, ddr: u32) -> Result<(), XtensaError> {
+        self.write_nexus_register(DebugDataRegister(ddr))?;
+        Ok(())
+    }
+
+    pub fn read_ddr_and_execute(&mut self) -> Result<u32, XtensaError> {
+        if let Some(instruction) = self.last_instruction {
+            tracing::debug!("Executing instruction via DDREXEC read: {:?}", instruction);
+        } else {
+            tracing::warn!("Reading DDREXEC without instruction");
+        }
+        let reg = self.read_nexus_register::<DebugDataAndExecRegister>()?;
+
+        self.wait_for_exec_done()?;
+
+        Ok(reg.bits())
+    }
+
+    pub fn write_ddr_and_execute(&mut self, ddr: u32) -> Result<(), XtensaError> {
+        if let Some(instruction) = self.last_instruction {
+            tracing::debug!("Executing instruction via DDREXEC write: {:?}", instruction);
+        } else {
+            tracing::warn!("Writing DDREXEC without instruction");
+        }
+        self.write_nexus_register(DebugDataAndExecRegister(ddr))?;
+
+        self.wait_for_exec_done()?;
+
+        Ok(())
+    }
+
+    fn free(self) -> Box<dyn JTAGAccess> {
+        self.probe
+    }
+}
+
+impl From<XtensaError> for crate::Error {
+    fn from(err: XtensaError) -> Self {
+        crate::Error::Xtensa(err)
+    }
+}
+
+impl From<Error> for XtensaError {
+    fn from(e: Error) -> Self {
+        XtensaError::XdmError(e)
+    }
+}
+
+impl From<DebugRegisterError> for Error {
+    fn from(e: DebugRegisterError) -> Self {
+        Error::Xdm(e)
+    }
+}
+
+// TODO: I don't think these should be transformed into XtensaError directly. We might want to
+// attach register-specific messages via an in-between type.
+impl From<DebugRegisterError> for XtensaError {
+    fn from(e: DebugRegisterError) -> Self {
+        XtensaError::XdmError(e.into())
+    }
+}
+
+bitfield::bitfield! {
+    #[derive(Copy, Clone)]
+    pub struct PowerControl(u8);
+
+    pub core_wakeup,    set_core_wakeup:    0;
+    pub mem_wakeup,     set_mem_wakeup:     1;
+    pub debug_wakeup,   set_debug_wakeup:   2;
+    pub core_reset,     set_core_reset:     4;
+    pub debug_reset,    set_debug_reset:    6;
+    pub jtag_debug_use, set_jtag_debug_use: 7;
+}
+
+bitfield::bitfield! {
+    #[derive(Copy, Clone)]
+    pub struct PowerStatus(u8);
+
+    pub core_domain_on,    _: 0;
+    pub mem_domain_on,     _: 1;
+    pub debug_domain_on,   _: 2;
+    pub core_still_needed, _: 3;
+    /// Clears bit when written as 1
+    pub core_was_reset,    set_core_was_reset: 4;
+    /// Clears bit when written as 1
+    pub debug_was_reset,   set_debug_was_reset: 6;
+}
+
+bitfield::bitfield! {
+    #[derive(Copy, Clone)]
+    pub struct DebugStatus(u32);
+    impl Debug;
+
+    // Cleared by writing 1
+    pub exec_done,         set_exec_done: 0;
+    // Cleared by writing 1
+    pub exec_exception,    set_exec_exception: 1;
+    pub exec_busy,         _: 2;
+    // Cleared by writing 1
+    pub exec_overrun,      set_exec_overrun: 3;
+    pub stopped,           _: 4;
+    // Cleared by writing 1
+    pub core_wrote_ddr,    set_core_wrote_ddr: 10;
+    // Cleared by writing 1
+    pub core_read_ddr,     set_core_read_ddr: 11;
+    // Cleared by writing 1
+    pub host_wrote_ddr,    set_host_wrote_ddr: 14;
+    // Cleared by writing 1
+    pub host_read_ddr,     set_host_read_ddr: 15;
+    // Cleared by writing 1
+    pub debug_pend_break,  set_debug_pend_break: 16;
+    // Cleared by writing 1
+    pub debug_pend_host,   set_debug_pend_host: 17;
+    // Cleared by writing 1
+    pub debug_pend_trax,   set_debug_pend_trax: 18;
+    // Cleared by writing 1
+    pub debug_int_break,   set_debug_int_break: 20;
+    // Cleared by writing 1
+    pub debug_int_host,    set_debug_int_host: 21;
+    // Cleared by writing 1
+    pub debug_int_trax,    set_debug_int_trax: 22;
+    // Cleared by writing 1
+    pub run_stall_toggle,  set_run_stall_toggle: 23;
+    pub run_stall_sample,  _: 24;
+    pub break_out_ack_iti, _: 25;
+    pub break_in_iti,      _: 26;
+    pub dbgmod_power_on,   _: 31;
+}
+
+impl DebugStatus {
+    pub fn is_ok(&self) -> Result<(), Error> {
+        if self.exec_exception() {
+            Err(Error::ExecExeception)
+        } else if self.exec_busy() {
+            Err(Error::ExecBusy)
+        } else if self.exec_overrun() {
+            Err(Error::ExecOverrun)
+        } else if !self.dbgmod_power_on() {
+            // should always be set to one
+            Err(Error::XdmPoweredOff)
+        } else {
+            Ok(())
+        }
+    }
+}
+
+/// An abstraction over all registers that can be accessed via the NAR/NDR instruction pair.
+trait NexusRegister: Sized + Copy + Debug {
+    /// NAR register address
+    const ADDRESS: u8;
+    const NAME: &'static str;
+
+    fn from_bits(bits: u32) -> Result<Self, XtensaError>;
+    fn bits(&self) -> u32;
+}
+
+impl NexusRegister for DebugStatus {
+    const ADDRESS: u8 = NARADR_DSR;
+    const NAME: &'static str = "DebugStatus";
+
+    fn from_bits(bits: u32) -> Result<Self, XtensaError> {
+        Ok(Self(bits))
+    }
+
+    fn bits(&self) -> u32 {
+        self.0
+    }
+}
+
+bitfield::bitfield! {
+    #[derive(Copy, Clone)]
+    pub struct DebugControlBits(u32);
+    impl Debug;
+
+    pub enable_ocd,          set_enable_ocd         : 0;
+    // R/set
+    pub debug_interrupt,     set_debug_interrupt    : 1;
+    pub interrupt_all_conds, set_interrupt_all_conds: 2;
+
+    pub break_in_en,         set_break_in_en        : 16;
+    pub break_out_en,        set_break_out_en       : 17;
+
+    pub debug_sw_active,     set_debug_sw_active    : 20;
+    pub run_stall_in_en,     set_run_stall_in_en    : 21;
+    pub debug_mode_out_en,   set_debug_mode_out_en  : 22;
+
+    pub break_out_ito,       set_break_out_ito      : 24;
+    pub break_in_ack_ito,    set_break_in_ack_ito   : 25;
+}
+
+#[derive(Copy, Clone, Debug)]
+/// Bits written as 1 are set to 1 in hardware.
+struct DebugControlSet(DebugControlBits);
+
+impl NexusRegister for DebugControlSet {
+    const ADDRESS: u8 = NARADR_DCRSET;
+    const NAME: &'static str = "DebugControlSet";
+
+    fn from_bits(bits: u32) -> Result<Self, XtensaError> {
+        Ok(Self(DebugControlBits(bits)))
+    }
+
+    fn bits(&self) -> u32 {
+        self.0 .0
+    }
+}
+
+#[derive(Copy, Clone, Debug)]
+/// Bits written as 1 are set to 0 in hardware.
+struct DebugControlClear(DebugControlBits);
+
+impl NexusRegister for DebugControlClear {
+    const ADDRESS: u8 = NARADR_DCRCLR;
+    const NAME: &'static str = "DebugControlClear";
+
+    fn from_bits(bits: u32) -> Result<Self, XtensaError> {
+        Ok(Self(DebugControlBits(bits)))
+    }
+
+    fn bits(&self) -> u32 {
+        self.0 .0
+    }
+}
+
+/// Writes DDR.
+#[derive(Copy, Clone, Debug)]
+struct DebugDataRegister(u32);
+
+impl NexusRegister for DebugDataRegister {
+    const ADDRESS: u8 = NARADR_DDR;
+    const NAME: &'static str = "DDR";
+
+    fn from_bits(bits: u32) -> Result<Self, XtensaError> {
+        Ok(Self(bits))
+    }
+
+    fn bits(&self) -> u32 {
+        self.0
+    }
+}
+
+/// Writes DDR and executes DIR on write AND READ.
+#[derive(Copy, Clone, Debug)]
+struct DebugDataAndExecRegister(u32);
+
+impl NexusRegister for DebugDataAndExecRegister {
+    const ADDRESS: u8 = NARADR_DDREXEC;
+    const NAME: &'static str = "DDREXEC";
+
+    fn from_bits(bits: u32) -> Result<Self, XtensaError> {
+        Ok(Self(bits))
+    }
+
+    fn bits(&self) -> u32 {
+        self.0
+    }
+}
+
+/// Writes DIR.
+#[derive(Copy, Clone, Debug)]
+struct DebugInstructionRegister(u32);
+
+impl NexusRegister for DebugInstructionRegister {
+    const ADDRESS: u8 = NARADR_DIR0;
+    const NAME: &'static str = "DIR0";
+
+    fn from_bits(bits: u32) -> Result<Self, XtensaError> {
+        Ok(Self(bits))
+    }
+
+    fn bits(&self) -> u32 {
+        self.0
+    }
+}
+
+/// Writes and executes DIR.
+#[derive(Copy, Clone, Debug)]
+struct DebugInstructionAndExecRegister(u32);
+
+impl NexusRegister for DebugInstructionAndExecRegister {
+    const ADDRESS: u8 = NARADR_DIR0EXEC;
+    const NAME: &'static str = "DIR0EXEC";
+
+    fn from_bits(bits: u32) -> Result<Self, XtensaError> {
+        Ok(Self(bits))
+    }
+
+    fn bits(&self) -> u32 {
+        self.0
+    }
+}

--- a/probe-rs/src/error.rs
+++ b/probe-rs/src/error.rs
@@ -2,6 +2,7 @@
 
 use crate::architecture::arm::ArmError;
 use crate::architecture::riscv::communication_interface::RiscvError;
+use crate::architecture::xtensa::communication_interface::XtensaError;
 use crate::config::RegistryError;
 use crate::DebugProbeError;
 
@@ -17,6 +18,9 @@ pub enum Error {
     /// A RISC-V specific error occurred.
     #[error("A RISC-V specific error occurred.")]
     Riscv(#[source] RiscvError),
+    /// An Xtensa specific error occurred.
+    #[error("An Xtensa specific error occurred.")]
+    Xtensa(#[source] XtensaError),
     /// The probe could not be opened.
     #[error("Probe could not be opened: {0}")]
     UnableToOpenProbe(&'static str),

--- a/probe-rs/src/probe.rs
+++ b/probe-rs/src/probe.rs
@@ -13,6 +13,7 @@ pub(crate) mod wlink;
 
 use crate::architecture::arm::ArmError;
 use crate::architecture::riscv::communication_interface::RiscvError;
+use crate::architecture::xtensa::communication_interface::XtensaCommunicationInterface;
 use crate::error::Error;
 use crate::{
     architecture::arm::communication_interface::UninitializedArmProbe,
@@ -386,6 +387,29 @@ impl Probe {
     }
 
     /// Check if the probe has an interface to
+    /// debug Xtensa chips.
+    pub fn has_xtensa_interface(&self) -> bool {
+        self.inner.has_xtensa_interface()
+    }
+
+    /// Try to get a [`XtensaCommunicationInterface`], which can
+    /// can be used to communicate with chips using the Xtensa
+    /// architecture.
+    ///
+    /// If an error occurs while trying to connect, the probe is returned.
+    pub fn try_into_xtensa_interface(
+        self,
+    ) -> Result<XtensaCommunicationInterface, (Self, DebugProbeError)> {
+        if !self.attached {
+            Err((self, DebugProbeError::NotAttached))
+        } else {
+            self.inner
+                .try_get_xtensa_interface()
+                .map_err(|(probe, err)| (Probe::from_attached_probe(probe), err))
+        }
+    }
+
+    /// Check if the probe has an interface to
     /// debug ARM chips.
     pub fn has_arm_interface(&self) -> bool {
         self.inner.has_arm_interface()
@@ -571,6 +595,22 @@ pub trait DebugProbe: Send + fmt::Debug {
 
     /// Check if the probe offers an interface to debug RISC-V chips.
     fn has_riscv_interface(&self) -> bool {
+        false
+    }
+
+    /// Get the dedicated interface to debug Xtensa chips. Ensure that the
+    /// probe actually supports this by calling [DebugProbe::has_xtensa_interface] first.
+    fn try_get_xtensa_interface(
+        self: Box<Self>,
+    ) -> Result<XtensaCommunicationInterface, (Box<dyn DebugProbe>, DebugProbeError)> {
+        Err((
+            self.into_probe(),
+            DebugProbeError::InterfaceNotAvailable("Xtensa"),
+        ))
+    }
+
+    /// Check if the probe offers an interface to debug Xtensa chips.
+    fn has_xtensa_interface(&self) -> bool {
         false
     }
 

--- a/probe-rs/src/probe/espusbjtag/mod.rs
+++ b/probe-rs/src/probe/espusbjtag/mod.rs
@@ -9,6 +9,7 @@ use crate::{
             SwoAccess,
         },
         riscv::communication_interface::{RiscvCommunicationInterface, RiscvError},
+        xtensa::communication_interface::XtensaCommunicationInterface,
     },
     probe::{
         common::extract_ir_lengths,
@@ -588,5 +589,19 @@ impl DebugProbe for EspUsbJtag {
     fn get_target_voltage(&mut self) -> Result<Option<f32>, DebugProbeError> {
         // We cannot read the voltage on this probe, unfortunately.
         Ok(None)
+    }
+
+    fn try_get_xtensa_interface(
+        self: Box<Self>,
+    ) -> Result<XtensaCommunicationInterface, (Box<dyn DebugProbe>, DebugProbeError)> {
+        // This probe is intended for Xtensa.
+        match XtensaCommunicationInterface::new(self) {
+            Ok(interface) => Ok(interface),
+            Err((probe, err)) => Err((probe.into_probe(), err)),
+        }
+    }
+
+    fn has_xtensa_interface(&self) -> bool {
+        true
     }
 }

--- a/probe-rs/src/probe/ftdi/mod.rs
+++ b/probe-rs/src/probe/ftdi/mod.rs
@@ -1,4 +1,5 @@
 use crate::architecture::riscv::communication_interface::RiscvError;
+use crate::architecture::xtensa::communication_interface::XtensaCommunicationInterface;
 use crate::architecture::{
     arm::communication_interface::UninitializedArmProbe,
     riscv::communication_interface::RiscvCommunicationInterface,
@@ -555,6 +556,20 @@ impl DebugProbe for FtdiProbe {
     ) -> Result<Box<dyn UninitializedArmProbe + 'probe>, (Box<dyn DebugProbe>, DebugProbeError)>
     {
         todo!()
+    }
+
+    fn try_get_xtensa_interface(
+        self: Box<Self>,
+    ) -> Result<XtensaCommunicationInterface, (Box<dyn DebugProbe>, DebugProbeError)> {
+        // This probe is intended for Xtensa.
+        match XtensaCommunicationInterface::new(self) {
+            Ok(interface) => Ok(interface),
+            Err((probe, err)) => Err((probe.into_probe(), err)),
+        }
+    }
+
+    fn has_xtensa_interface(&self) -> bool {
+        true
     }
 }
 

--- a/probe-rs/src/probe/jlink/mod.rs
+++ b/probe-rs/src/probe/jlink/mod.rs
@@ -9,6 +9,7 @@ use std::time::{Duration, Instant};
 
 use crate::architecture::arm::{ArmError, RawDapAccess};
 use crate::architecture::riscv::communication_interface::RiscvError;
+use crate::architecture::xtensa::communication_interface::XtensaCommunicationInterface;
 use crate::probe::common::bits_to_byte;
 use crate::{
     architecture::{
@@ -620,6 +621,20 @@ impl DebugProbe for JLink {
     fn get_target_voltage(&mut self) -> Result<Option<f32>, DebugProbeError> {
         // Convert the integer millivolts value from self.handle to volts as an f32.
         Ok(Some((self.handle.read_target_voltage()? as f32) / 1000f32))
+    }
+
+    fn try_get_xtensa_interface(
+        self: Box<Self>,
+    ) -> Result<XtensaCommunicationInterface, (Box<dyn DebugProbe>, DebugProbeError)> {
+        // This probe is intended for Xtensa.
+        match XtensaCommunicationInterface::new(self) {
+            Ok(interface) => Ok(interface),
+            Err((probe, err)) => Err((probe.into_probe(), err)),
+        }
+    }
+
+    fn has_xtensa_interface(&self) -> bool {
+        true
     }
 }
 

--- a/smoke-tester/Cargo.toml
+++ b/smoke-tester/Cargo.toml
@@ -16,4 +16,4 @@ serde = { version = "1", features = ["derive"] }
 pretty_env_logger = "0.5.0"
 log = "0.4.20"
 clap = "4.4"
-colored = "2.0.4"
+colored = "2.1.0"

--- a/target-gen/Cargo.toml
+++ b/target-gen/Cargo.toml
@@ -38,7 +38,7 @@ anyhow = "1.0.75"
 reqwest = { version = "0.11.22", features = ["json", "blocking", "rustls-tls"], default-features = false }
 serde = { version = "1", features = ["derive"] }
 futures = "0.3.29"
-tokio = { version = "1.34.0", features = ["macros", "rt", "rt-multi-thread"] }
+tokio = { version = "1.35.0", features = ["macros", "rt", "rt-multi-thread"] }
 tracing-subscriber = { version = "0.3.18", features = [
     "env-filter",
     "tracing-log",


### PR DESCRIPTION
Just putting it here so I won't forget what this branch is for

ESP32 Xtensas don't use the Xtensa cache but others do, e.g. https://www.nxp.com/products/processors-and-microcontrollers/arm-microcontrollers/i-mx-rt-crossover-mcus/i-mx-rt600-crossover-mcu-with-arm-cortex-m33-and-dsp-cores:i.MX-RT600 and we may or may not want to support that in probe-rs in the future.